### PR TITLE
Removed deploy workflow in circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,19 +40,3 @@ jobs:
           path: test-results
       - store_artifacts:
           path: htmlcov
-
-  deploy:
-    steps:
-      - checkout
-      - run: docker test -t muchogo/django_web:v4 .
-      - run: docker login -u muchogo -p %X4$@62iLRza
-      - run: docker push muchogo/django_web:v4
-
-workflows:
-  version: 2
-  test-and-deploy:
-    jobs:
-      - test
-      - deploy:
-          requires:
-            - test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "python.pythonPath": "/home/muchogo/Documents/backend_basics/python/django/test/finalize/bin/python",
-    "python.linting.flake8Enabled": true,
-    "python.linting.pep8Enabled": false,
-    "python.linting.enabled": true
-}


### PR DESCRIPTION
The job fails due to a lack of a custom image thus need to be solved first
before continuing. i.e create a custom docker base image and publish to docker
hub.