### PR TITLE
Remove approval in circleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,14 @@ workflows:
     jobs:
       - test
       - publish:
+          requires:
+            - test
           filters:
             branches:
               only: master
       - deploy:
+          requires:
+            - test
           filters:
             branches:
               only: master


### PR DESCRIPTION
The publish and deploy take place automatically without manual
approval in circleCI. They both require the test to pass in order to
be done.